### PR TITLE
security: add protected PDF download route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ next-env.d.ts
 
 /src/generated/prisma
 
+# Private PDF storage (serve via protected API route only)
+/private/pdfs/*.pdf
+
 # SQLite databases
 *.db
 prisma/dev.db

--- a/private/pdfs/README.txt
+++ b/private/pdfs/README.txt
@@ -1,0 +1,1 @@
+Place PDF files here (not in public/)

--- a/src/app/api/ebooks/[id]/pdf/route.ts
+++ b/src/app/api/ebooks/[id]/pdf/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  // 1. Validate authentication
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 2. Check active subscription
+  const assinaturaAtiva = (session.user as any).assinaturaAtiva;
+  if (!assinaturaAtiva) {
+    return NextResponse.json(
+      { error: "Assinatura inativa. Renov e seu plano para acessar." },
+      { status: 403 }
+    );
+  }
+
+  // 3. Parse ebook ID
+  const { id } = await params;
+  const ebookId = parseInt(id, 10);
+  if (isNaN(ebookId)) {
+    return NextResponse.json({ error: "ID inválido" }, { status: 400 });
+  }
+
+  // 4. Fetch ebook from database
+  const ebook = await prisma.ebook.findUnique({
+    where: { id: ebookId },
+  });
+
+  if (!ebook) {
+    return NextResponse.json({ error: "E-book não encontrado" }, { status: 404 });
+  }
+
+  // 5. Resolve PDF path
+  // The pdf field contains a filename (e.g. "ebook.pdf")
+  // PDFs are served from /private/pdfs/ (outside public/)
+  const pdfFilename = path.basename(ebook.pdf);
+  const pdfPath = path.join(process.cwd(), "private", "pdfs", pdfFilename);
+
+  // Security: ensure the resolved path is actually inside the pdfs directory
+  const pdfsDir = path.join(process.cwd(), "private", "pdfs");
+  if (!pdfPath.startsWith(pdfsDir)) {
+    return NextResponse.json({ error: "Caminho inválido" }, { status: 400 });
+  }
+
+  // 6. Check if file exists
+  let fileBuffer: Buffer;
+  try {
+    fileBuffer = await fs.readFile(pdfPath);
+  } catch {
+    // If file not found, return a structured JSON error instead of crashing
+    return NextResponse.json(
+      { error: "Arquivo PDF não encontrado no servidor. Entre em contato com o suporte." },
+      { status: 404 }
+    );
+  }
+
+  // 7. Increment download counter
+  await prisma.ebook.update({
+    where: { id: ebookId },
+    data: { contadorDownloads: { increment: 1 } },
+  });
+
+  // 8. Serve the PDF with proper headers
+  return new NextResponse(new Uint8Array(fileBuffer), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="${pdfFilename}"`,
+      "Content-Length": fileBuffer.length.toString(),
+      "Cache-Control": "private, no-cache, no-store, must-revalidate",
+      "Pragma": "no-cache",
+      "Expires": "0",
+    },
+  });
+}

--- a/src/app/vitrine/[id]/page.tsx
+++ b/src/app/vitrine/[id]/page.tsx
@@ -123,7 +123,7 @@ export default function VitrineDetailPage() {
               {/* Action buttons */}
               <div className="mt-6 flex flex-col gap-3">
                 <a
-                  href={ebook.pdf}
+                  href={`/api/ebooks/${id}/pdf`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center justify-center gap-2 rounded-lg px-6 py-3 font-semibold transition hover:opacity-90"
@@ -149,7 +149,7 @@ export default function VitrineDetailPage() {
                   Ler Agora
                 </a>
                 <a
-                  href={ebook.pdf}
+                  href={`/api/ebooks/${id}/pdf`}
                   download
                   className="flex items-center justify-center gap-2 rounded-lg px-6 py-3 font-semibold transition hover:opacity-90"
                   style={{


### PR DESCRIPTION
## Summary

Creates a protected API route `/api/ebooks/[id]/pdf` that:
- Requires authenticated user with active subscription
- Serves PDFs from `private/pdfs/` (outside `public/`)
- Increments `contadorDownloads` on each access
- Updates `/vitrine/[id]` buttons to use the protected route

### Files
- `src/app/api/ebooks/[id]/pdf/route.ts` (new)
- `src/app/vitrine/[id]/page.tsx` (updated)
- `private/pdfs/` (new dir)
- `.gitignore`