### PR TITLE
security: replace Math.random() with crypto.randomUUID() for password generation

### DIFF
--- a/src/app/api/employees/[id]/route.ts
+++ b/src/app/api/employees/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import bcrypt from "bcryptjs";
+import { randomUUID } from "crypto";
 
 type Context = { params: Promise<{ id: string }> };
 
@@ -51,7 +52,7 @@ export async function PUT(req: NextRequest, { params }: Context) {
   });
 
   if (resetPassword && employee.userId) {
-    const newPassword = Math.random().toString(36).slice(-8);
+    const newPassword = randomUUID().slice(0, 8);
     const hashed = await bcrypt.hash(newPassword, 10);
     await prisma.user.update({
       where: { id: employee.userId },

--- a/src/app/api/employees/route.ts
+++ b/src/app/api/employees/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 import bcrypt from "bcryptjs";
+import { randomUUID } from "crypto";
 
 export async function GET() {
   const session = await auth();
@@ -53,7 +54,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const password = initialPassword || Math.random().toString(36).slice(-8);
+  const password = initialPassword || randomUUID().slice(0, 8);
   const hashedPassword = await bcrypt.hash(password, 10);
 
   const user = await prisma.user.create({

--- a/src/components/ManageTeam.tsx
+++ b/src/components/ManageTeam.tsx
@@ -110,7 +110,7 @@ export default function ManageTeam() {
   }
 
   function startResetPwd(emp: Employee) {
-    const newPassword = Math.random().toString(36).slice(-8);
+    const newPassword = crypto.randomUUID().slice(0, 8);
     fetch(`/api/employees/${emp.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

`Math.random()` is predictable and must not be used for security-sensitive tokens like passwords.

Replaced all occurrences with `crypto.randomUUID()` (available in Node.js 14.17+).

### Affected files
- `src/app/api/employees/route.ts`: initial employee password generation
- `src/app/api/employees/[id]/route.ts`: password reset token generation
- `src/components/ManageTeam.tsx`: client-side password reset display