### PR TITLE
Fix: adicionar prisma db push no start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
-    "start": "next start",
+    "start": "prisma db push --accept-data-loss && next start",
     "lint": "eslint",
     "db:seed": "tsx prisma/seed.ts",
     "test": "vitest run",


### PR DESCRIPTION
Atualiza o script `start` no `package.json` para rodar `prisma db push` antes de subir o servidor.

Assim funciona automaticamente no Coolify (e em qualquer plataforma) sem precisar configurar nada no painel.

```json
"start": "prisma db push --accept-data-loss && next start"
```

https://claude.ai/code/session_01H8M5T3DTUQsRQe1YtL34y1